### PR TITLE
Updated EmailSender in email_handling.py to incorporate multiple fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,14 @@ db_manager = DatabaseManager(
 ### EmailSender (sync + async)
 `EmailSender` is for sending emails from a SMTP server. It takes both just email addresses (string) and address headers with names (tuple), like; `('Name', 'name@email.com)`.
 Emails with html body will get a plain text body added as well, fallback for email clients not supporting html. Attachments can be given either as a path to a file (string) or as filename and data in bytes (tuple).
+
+Address formats:
+- A single address can be given as a string email: `'to@example.com'`
+- A single named address can be given as a tuple: `('Name', 'to@example.com')`
+- Multiple recipients/CC must be given as a **non-tuple sequence** (typically a list), e.g. `['a@example.com', 'b@example.com']` or `[('A', 'a@example.com'), 'b@example.com']`
+
+Note: A 2-tuple is reserved for the named-address form `(name, email)`. Passing a tuple of two emails like `('a@example.com', 'b@example.com')` is not supported; use a list instead.
+
 #### Sync example
 ```python
 from rkdigi import EmailSender
@@ -148,7 +156,7 @@ email_sender.send_email(
 	sender=('No Reply', 'noreply@example.com'),
 	reply_to='real@example.com',
 	recipients='to@example.com',
-	cc=[('CC', 'cc@example.com')]
+	cc=[('CC', 'cc@example.com')],
 	subject='Test Subject',
 	body='<html><body>Test Body</body></html>',
 	attachments=[('myfile.txt', b'<somebytes>')]

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Emails with html body will get a plain text body added as well, fallback for ema
 Address formats:
 - A single address can be given as a string email: `'to@example.com'`
 - A single named address can be given as a tuple: `('Name', 'to@example.com')`
-- Multiple recipients/CC must be given as a **non-tuple sequence** (typically a list), e.g. `['a@example.com', 'b@example.com']` or `[('A', 'a@example.com'), 'b@example.com']`
+- Multiple recipients/CC must be given as a sequence (typically a list), e.g. `['a@example.com', 'b@example.com']`, `[('A', 'a@example.com'), 'b@example.com']` or `('a@example.com', ('B', 'b@example.com'))`
 
 Note: A 2-tuple is reserved for the named-address form `(name, email)`. Passing a tuple of two emails like `('a@example.com', 'b@example.com')` is not supported; use a list instead.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ license = "MIT"
 dependencies = [
   "requests_oauthlib>=1.3.1",
   "SQLAlchemy>=1.4",
-  "html2text>=3.0.0"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ Bug-Tracker = "https://github.com/Randers-Kommune-Digitalisering/rk-digi-package
 
 [project]
 name = "rk-digi"
-version = "1.1.0"
+version = "1.1.1"
 description = "Python package with useful stuff for projects in Randers Kommune - Digitalisering"
 authors = [
   { name = "Randers Kommune Digitalisering", email = "digitalisering@randers.dk" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ license = "MIT"
 dependencies = [
   "requests_oauthlib>=1.3.1",
   "SQLAlchemy>=1.4",
+  "beautifulsoup4>=4.0.0"
 ]
 
 [project.optional-dependencies]

--- a/src/rkdigi/email_handling.py
+++ b/src/rkdigi/email_handling.py
@@ -3,15 +3,16 @@ import re
 import asyncio
 import imaplib
 import smtplib
-from html import unescape
-from typing import Sequence, TypeGuard
+from typing import Sequence
 import email as email_module
 from email import encoders
-from email.utils import formataddr
+from email.utils import formataddr, parseaddr
 from email.message import EmailMessage
 from email.mime.base import MIMEBase
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
+
+from bs4 import BeautifulSoup
 
 
 class EmailSender:
@@ -37,7 +38,7 @@ class EmailSender:
         self.sender_email = sender_email
         self._sender_password = sender_password
         if sender_email:
-            if self._check_address_header(sender_email):
+            if self._is_valid_address(sender_email):
                 if sender_name:
                     self.sender = (sender_name, sender_email)
                 else:
@@ -50,7 +51,7 @@ class EmailSender:
             self.sender = ""
 
         if reply_to_email:
-            if self._check_address_header(reply_to_email):
+            if self._is_valid_address(reply_to_email):
                 if reply_to_name:
                     self.reply_to = (reply_to_name, reply_to_email)
                 else:
@@ -68,49 +69,30 @@ class EmailSender:
                 f"{self._smtp_server}:{self._smtp_port}"
             )
 
-    def _is_address_tuple(self, value: object) -> TypeGuard[tuple[str, str]]:
+    def _is_valid_address(self, address) -> bool:
         """
-        Method to check if the provided value is a valid address tuple of the form (name, email).
+        Validate an address header.
 
-        Tuples are reserved for a *single named address*.
-        Multiple recipients must be provided as a non-tuple sequence (e.g. list).
-
-        To prevent common misuse, we reject tuples where both elements look like
-        emails (e.g. ("a@x", "b@y")); pass ["a@x", "b@y"] instead.
-
-        :param value: The value to check.
-        :return: True if value is a valid (display_name, email) tuple, False otherwise.
+        Accepts either:
+        • a (name, email) tuple, or
+        • a plain email string.
         """
-        if not (isinstance(value, tuple) and len(value) == 2):
-            return False
-
-        name, email = value
-        if not (isinstance(name, str) and isinstance(email, str)):
-            return False
-
-        if "@" not in email:
-            return False
-
-        # Disallow "name" that also looks like an email to avoid ambiguity.
-        if "@" in name:
-            return False
-
-        return True
-
-    def _check_address_header(self, address: str | tuple[str, str] | None) -> bool:
-        """
-        Method to check if the provided address is a valid address header.
-
-        :param address: The email address to check. Can be a string or a tuple of (display_name, email), for example:
-        - Simple email string: "user@example.com"
-        - Tuple of (display_name, email): ("John Doe", "john.doe@example.com")
-
-        :return: True if the address is valid, False otherwise.
-        """
+        # Case 1: address is a plain string containing an email
         if isinstance(address, str):
-            return '@' in address
-        elif self._is_address_tuple(address):
+            parsed = parseaddr(address)[1]
+            return "@" in address and parsed == address
+
+        # Case 2: address is a (name, email) tuple
+        if (
+            isinstance(address, tuple)
+            and len(address) == 2
+            and isinstance(address[1], str)
+            and "@" in address[1]
+            and "@" not in address[0]
+            and parseaddr(formataddr(address))[1] == address[1]
+        ):
             return True
+
         return False
 
     def _can_connect(self) -> bool:
@@ -129,113 +111,27 @@ class EmailSender:
         except Exception:
             return False
 
-    def _is_html(self, body: str) -> bool:
-        """
-        Method to check if the provided body is HTML.
-        Returns True if the body contains HTML tags, False otherwise.
-        """
-        if not body:
-            return False
-        lower = body.lower()
-        if "<html" in lower:
-            return True
-        return bool(
-            re.search(
-                r"<\s*(p|br|div|span|table|a|body|head|style|strong|em|ul|ol|li)\b",
-                lower,
-            )
-        )
-
-    def _html_to_text(self, html: str) -> str:
-        """
-        Method to convert HTML content to plain text.
-        Returns the plain text representation of the HTML content.
-        """
-        if not html:
-            return ""
-
-        text = html
-        text = re.sub(
-            r"<\s*script[^>]*>.*?<\s*/\s*script\s*>",
-            "",
-            text,
-            flags=re.I | re.S,
-        )
-        text = re.sub(
-            r"<\s*style[^>]*>.*?<\s*/\s*style\s*>",
-            "",
-            text,
-            flags=re.I | re.S,
-        )
-
-        # Preserve links as: label (url)
-        link_pattern = re.compile(
-            r"<\s*a\b[^>]*?href\s*=\s*(['\"])(.*?)\1[^>]*>(.*?)<\s*/\s*a\s*>",
-            flags=re.I | re.S,
-        )
-
-        def link_repl(match: re.Match) -> str:
-            href = (match.group(2) or "").strip()
-            label_html = match.group(3) or ""
-            label = re.sub(r"<[^>]+>", "", label_html)
-            label = unescape(label).strip()
-            if not label:
-                return href
-            if label == href:
-                return href
-            return f"{label} ({href})"
-
-        text = link_pattern.sub(link_repl, text)
-
-        # Basic block separators
-        text = re.sub(r"<\s*br\s*/?\s*>", "\n", text, flags=re.I)
-        text = re.sub(r"<\s*/\s*p\s*>", "\n\n", text, flags=re.I)
-        text = re.sub(r"<\s*/\s*div\s*>", "\n", text, flags=re.I)
-
-        # Drop remaining tags.
-        text = re.sub(r"<[^>]+>", "", text)
-        text = unescape(text)
-
-        # Normalize whitespace.
-        text = re.sub(r"\r\n?", "\n", text)
-        text = re.sub(r"\n{3,}", "\n\n", text)
-        text = re.sub(r"[ \t]{2,}", " ", text)
-        return text.strip()
-
     def _normalize_addresses(
         self,
         addresses: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
     ) -> list[str | tuple[str, str]]:
         if addresses is None:
             return []
-        if isinstance(addresses, str):
+        if isinstance(addresses, str) and self._is_valid_address(addresses):
             return [addresses]
-        if isinstance(addresses, tuple):
-            if self._is_address_tuple(addresses):
-                return [addresses]
-            raise ValueError(
-                "Invalid address tuple. Use (name, email) for a single named address, "
-                "or use a list/other non-tuple sequence for multiple recipients."
-            )
+        elif isinstance(addresses, tuple) and self._is_valid_address(addresses):
+            return [addresses]
+        else:
+            for addr in addresses:
+                if not self._is_valid_address(addr):
+                    raise ValueError(f"Invalid email address: {addr}")
         return list(addresses)
-
-    def _normalize_recipients(
-        self,
-        recipients: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
-    ) -> list[str | tuple[str, str]]:
-        return self._normalize_addresses(recipients)
-
-    def _normalize_cc(
-        self,
-        cc: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
-    ) -> list[str | tuple[str, str]]:
-        return self._normalize_addresses(cc)
 
     def _build_message(
         self,
         sender: str | tuple[str, str],
         reply_to: str | tuple[str, str],
-        recipients: list[str | tuple[str, str]],
+        recipients: str | tuple[str, str] | Sequence[str | tuple[str, str]],
         subject: str,
         body: str,
         cc: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
@@ -246,12 +142,13 @@ class EmailSender:
         along with from_addr and to_addrs.
         """
         attachments = attachments or []
-        cc_list = self._normalize_cc(cc)
+        cc_list = self._normalize_addresses(cc)
+        recipients_list = self._normalize_addresses(recipients)
 
-        to_headers = recipients + cc_list
+        to_headers = recipients_list + cc_list
 
         for addr in [sender] + to_headers + ([reply_to] if reply_to else []):
-            if not self._check_address_header(addr):
+            if not self._is_valid_address(addr):
                 raise ValueError(f"Invalid email address: {addr}")
 
         msg = MIMEMultipart("mixed")
@@ -265,7 +162,7 @@ class EmailSender:
         if recipients:
             msg["To"] = ", ".join(
                 formataddr(addr) if isinstance(addr, tuple) else addr
-                for addr in recipients
+                for addr in recipients_list
             )
 
         if cc_list:
@@ -276,9 +173,11 @@ class EmailSender:
 
         msg["Subject"] = subject or ""
 
-        if self._is_html(body):
+        soup = BeautifulSoup(body, "html.parser")
+
+        if soup.find():  # If there are any HTML tags, treat as HTML email
             alt = MIMEMultipart("alternative")
-            alt.attach(MIMEText(self._html_to_text(body), "plain", "utf-8"))
+            alt.attach(MIMEText(soup.get_text(separator="\n", strip=True), "plain", "utf-8"))
             alt.attach(MIMEText(body, "html", "utf-8"))
             msg.attach(alt)
         else:
@@ -366,8 +265,7 @@ class EmailSender:
             if not sender:
                 raise ValueError("A sender must be specified.")
 
-            recipients_list = self._normalize_recipients(recipients)
-            if not recipients_list and not cc:
+            if not recipients and not cc:
                 raise ValueError(
                     "At least one recipient (recipients or cc) must be specified."
                 )
@@ -375,7 +273,7 @@ class EmailSender:
             msg, from_addr, to_addrs = self._build_message(
                 sender=sender,
                 reply_to=reply_to or self.reply_to,
-                recipients=recipients_list,
+                recipients=recipients,
                 subject=subject,
                 body=body,
                 cc=cc,
@@ -414,7 +312,7 @@ class EmailSender:
         if not sender:
             raise ValueError("A sender must be specified.")
 
-        recipients_list = self._normalize_recipients(recipients)
+        recipients_list = self._normalize_addresses(recipients)
         if not recipients_list and not cc:
             raise ValueError(
                 "At least one recipient (recipients or cc) must be specified."

--- a/src/rkdigi/email_handling.py
+++ b/src/rkdigi/email_handling.py
@@ -295,9 +295,9 @@ class EmailSender:
                     and len(att) == 2
                     and isinstance(att[0], str)
                     and isinstance(att[1], (bytes, bytearray, memoryview))):
-                # If value in attachments is
-                # a tuple of (filename, content)
-                # then only 'bytes' content is supported
+                # If value in attachments is a tuple of (filename, content),
+                # content may be bytes, bytearray, or memoryview and will be
+                # normalized to bytes before attaching.
                 filename, content = att[0], bytes(att[1])
             else:
                 raise ValueError(

--- a/src/rkdigi/email_handling.py
+++ b/src/rkdigi/email_handling.py
@@ -239,7 +239,7 @@ class EmailSender:
         subject: str,
         body: str,
         cc: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
-        attachments: Sequence[str | tuple[str, bytes]] | None
+        attachments: Sequence[str | tuple[str, bytes | bytearray | memoryview]] | None
     ) -> tuple[MIMEMultipart, str, Sequence[str]]:
         """
         Method to build the message object and return it
@@ -390,7 +390,7 @@ class EmailSender:
 
     async def send_email_async(
         self,
-        sender: str = "",
+        sender: str | tuple[str, str] = "",
         reply_to: str | tuple[str, str] | None = None,
         recipients: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None = None,
         subject: str = "",

--- a/src/rkdigi/email_handling.py
+++ b/src/rkdigi/email_handling.py
@@ -1,7 +1,9 @@
 import os
+import re
 import asyncio
 import imaplib
 import smtplib
+from html import unescape
 from typing import Sequence
 import email as email_module
 from email import encoders
@@ -10,8 +12,6 @@ from email.message import EmailMessage
 from email.mime.base import MIMEBase
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
-
-import html2text
 
 
 class EmailSender:
@@ -94,6 +94,91 @@ class EmailSender:
         except Exception:
             return False
 
+    def _is_html(self, body: str) -> bool:
+        if not body:
+            return False
+        lower = body.lower()
+        if "<html" in lower:
+            return True
+        return bool(
+            re.search(
+                r"<\s*(p|br|div|span|table|a|body|head|style|strong|em|ul|ol|li)\b",
+                lower,
+            )
+        )
+
+    def _html_to_text(self, html: str) -> str:
+        if not html:
+            return ""
+
+        text = html
+        text = re.sub(
+            r"<\s*script[^>]*>.*?<\s*/\s*script\s*>",
+            "",
+            text,
+            flags=re.I | re.S,
+        )
+        text = re.sub(
+            r"<\s*style[^>]*>.*?<\s*/\s*style\s*>",
+            "",
+            text,
+            flags=re.I | re.S,
+        )
+
+        # Preserve links as: label (url)
+        link_pattern = re.compile(
+            r"<\s*a\b[^>]*?href\s*=\s*(['\"])(.*?)\1[^>]*>(.*?)<\s*/\s*a\s*>",
+            flags=re.I | re.S,
+        )
+
+        def link_repl(match: re.Match) -> str:
+            href = (match.group(2) or "").strip()
+            label_html = match.group(3) or ""
+            label = re.sub(r"<[^>]+>", "", label_html)
+            label = unescape(label).strip()
+            if not label:
+                return href
+            if label == href:
+                return href
+            return f"{label} ({href})"
+
+        text = link_pattern.sub(link_repl, text)
+
+        # Basic block separators
+        text = re.sub(r"<\s*br\s*/?\s*>", "\n", text, flags=re.I)
+        text = re.sub(r"<\s*/\s*p\s*>", "\n\n", text, flags=re.I)
+        text = re.sub(r"<\s*/\s*div\s*>", "\n", text, flags=re.I)
+
+        # Drop remaining tags.
+        text = re.sub(r"<[^>]+>", "", text)
+        text = unescape(text)
+
+        # Normalize whitespace.
+        text = re.sub(r"\r\n?", "\n", text)
+        text = re.sub(r"\n{3,}", "\n\n", text)
+        text = re.sub(r"[ \t]{2,}", " ", text)
+        return text.strip()
+
+    def _normalize_recipients(
+        self,
+        recipients: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
+    ) -> list[str | tuple[str, str]]:
+        if recipients is None:
+            return []
+        if isinstance(recipients, (str, tuple)):
+            return [recipients]
+        return list(recipients)
+
+    def _normalize_cc(
+        self,
+        cc: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
+    ) -> list[str | tuple[str, str]]:
+        if cc is None:
+            return []
+        if isinstance(cc, (str, tuple)):
+            return [cc]
+        return list(cc)
+
     def _build_message(
         self,
         sender: str | tuple[str, str],
@@ -101,19 +186,15 @@ class EmailSender:
         recipients: list[str | tuple[str, str]],
         subject: str,
         body: str,
-        cc: str | tuple[str, str] | list[str | tuple[str, str]] | None,
+        cc: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
         attachments: Sequence[str | tuple[str, bytes]] | None
     ) -> tuple[MIMEMultipart, str, Sequence[str]]:
         """
         Method to build the message object and return it
         along with from_addr and to_addrs.
         """
-        if cc is None:
-            cc = []
-        if attachments is None:
-            attachments = []
-
-        cc_list = [cc] if isinstance(cc, str) or isinstance(cc, tuple) else cc
+        attachments = attachments or []
+        cc_list = self._normalize_cc(cc)
 
         to_headers = recipients + cc_list
 
@@ -121,7 +202,7 @@ class EmailSender:
             if not self._check_address_header(addr):
                 raise ValueError(f"Invalid email address: {addr}")
 
-        msg = MIMEMultipart()
+        msg = MIMEMultipart("mixed")
         msg["From"] = formataddr(sender) if isinstance(sender, tuple) \
             else sender
 
@@ -143,51 +224,43 @@ class EmailSender:
 
         msg["Subject"] = subject or ""
 
-        body_part = MIMEText(body, "html") \
-            if body and "<html>" in body.lower() \
-            else MIMEText(body or " ", "plain")
-
-        if body_part.get_content_subtype() == "html":
-            plain_text = html2text.html2text(body)
-            msg.attach(MIMEText(plain_text, "plain"))
-
-        msg.attach(body_part)
+        if self._is_html(body):
+            alt = MIMEMultipart("alternative")
+            alt.attach(MIMEText(self._html_to_text(body), "plain", "utf-8"))
+            alt.attach(MIMEText(body, "html", "utf-8"))
+            msg.attach(alt)
+        else:
+            msg.attach(MIMEText(body or "", "plain", "utf-8"))
 
         for att in attachments:
             if isinstance(att, str):
                 # If value in attachments is a string,
                 # treat it as a file path
                 with open(att, "rb") as f:
-                    part = MIMEBase("application", "octet-stream")
-                    part.set_payload(f.read())
-                encoders.encode_base64(part)
-                filename = os.path.basename(att)
-                part.add_header(
-                    "Content-Disposition",
-                    f'attachment; filename="{filename}"'
-                )
-                msg.attach(part)
+                    filename = os.path.basename(att)
+                    content = f.read()
             elif (isinstance(att, tuple)
                     and len(att) == 2
                     and isinstance(att[0], str)
-                    and isinstance(att[1], bytes)):
+                    and isinstance(att[1], (bytes, bytearray, memoryview))):
                 # If value in attachments is
                 # a tuple of (filename, content)
                 # then only 'bytes' content is supported
-                filename, content = att
-                part = MIMEBase("application", "octet-stream")
-                part.set_payload(content)
-                encoders.encode_base64(part)
-                part.add_header(
-                    "Content-Disposition",
-                    f'attachment; filename="{filename}"'
-                )
-                msg.attach(part)
+                filename, content = att[0], bytes(att[1])
             else:
                 raise ValueError(
                     "Attachments must be file paths "
                     "or (filename, content) tuples."
                 )
+
+            part = MIMEBase("application", "octet-stream")
+            part.set_payload(content)
+            encoders.encode_base64(part)
+            part.add_header(
+                "Content-Disposition",
+                f'attachment; filename="{filename}"'
+            )
+            msg.attach(part)
         from_addr = sender[1] if isinstance(sender, tuple) else sender
         to_addrs = [
             addr[1] if isinstance(addr, tuple) else addr
@@ -203,7 +276,7 @@ class EmailSender:
         reply_to: str | tuple[str, str] = "",
         subject: str = "",
         body: str = "",
-        cc: str | list[str | tuple[str, str]] | None = None,
+        cc: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None = None,
         attachments: Sequence[str | tuple[str, bytes]] | None = None
     ) -> None:
         """
@@ -216,7 +289,13 @@ class EmailSender:
             port=self._smtp_port,
             timeout=60
         ) as server:
-            server.starttls()
+            server.ehlo()
+            try:
+                server.starttls()
+                server.ehlo()
+            except smtplib.SMTPException:
+                # STARTTLS may be unsupported on some port 25 setups.
+                pass
             if self.sender_email and self._sender_password:
                 if sender:
                     raise ValueError(
@@ -231,14 +310,14 @@ class EmailSender:
 
             sender = sender or self.sender or self.sender_email
 
-            if not sender or not recipients and not cc:
-                raise ValueError(
-                    "A sender and at least one recipient "
-                    "(recipients or cc) must be specified."
-                )
+            if not sender:
+                raise ValueError("A sender must be specified.")
 
-            recipients_list = [recipients] if isinstance(recipients, str) \
-                else recipients
+            recipients_list = self._normalize_recipients(recipients)
+            if not recipients_list and not cc:
+                raise ValueError(
+                    "At least one recipient (recipients or cc) must be specified."
+                )
 
             msg, from_addr, to_addrs = self._build_message(
                 sender=sender,
@@ -260,10 +339,10 @@ class EmailSender:
         self,
         sender: str = "",
         reply_to: str | tuple[str, str] | None = None,
-        recipients: str | Sequence[str] | None = None,
+        recipients: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None = None,
         subject: str = "",
         body: str = "",
-        cc: str | Sequence[str] | None = None,
+        cc: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None = None,
         attachments: Sequence[str | tuple[str, bytes]] | None = None
     ) -> None:
         """
@@ -272,23 +351,21 @@ class EmailSender:
         if sender_email and sender_password were provided in the constructor.
         """
         import aiosmtplib
-        if self.sender_email and self._sender_password:
-            if sender:
-                raise ValueError(
-                    "Cannot specify sender when using "
-                    "authenticated email sending."
-                )
+        if self.sender_email and self._sender_password and sender:
+            raise ValueError(
+                "Cannot specify sender when using authenticated email sending."
+            )
 
         sender = sender or self.sender or self.sender_email
 
-        if not sender or not recipients and not cc:
-            raise ValueError(
-                "A sender and at least one recipient "
-                "(recipients or cc) must be specified."
-            )
+        if not sender:
+            raise ValueError("A sender must be specified.")
 
-        recipients_list = [recipients] if isinstance(recipients, str) \
-            else recipients
+        recipients_list = self._normalize_recipients(recipients)
+        if not recipients_list and not cc:
+            raise ValueError(
+                "At least one recipient (recipients or cc) must be specified."
+            )
 
         msg, from_addr, to_addrs = self._build_message(
             sender=sender,
@@ -300,11 +377,11 @@ class EmailSender:
             attachments=attachments
         )
 
-        smtp_kwargs = dict(
-            hostname=self._smtp_server,
-            port=self._smtp_port,
-            start_tls=True,
-        )
+        smtp_kwargs: dict[str, object] = {
+            "hostname": self._smtp_server,
+            "port": self._smtp_port,
+            "start_tls": True,
+        }
 
         if self.sender_email and self._sender_password:
             smtp_kwargs["username"] = self.sender_email

--- a/src/rkdigi/email_handling.py
+++ b/src/rkdigi/email_handling.py
@@ -333,7 +333,7 @@ class EmailSender:
     ) -> None:
         """
         Sends an email with the specified parameters (sync).
-        Will try to authenticate with the SMTP server
+        Will try to authenticate with the SMTP server.
         if sender_email and sender_password were provided in the constructor.
         """
         with smtplib.SMTP(
@@ -347,6 +347,7 @@ class EmailSender:
                 server.ehlo()
             except smtplib.SMTPException:
                 # STARTTLS may be unsupported on some port 25 setups.
+                # Fallback to unencrypted connection if STARTTLS fails or is not supported.
                 pass
             if self.sender_email and self._sender_password:
                 if sender:
@@ -399,7 +400,7 @@ class EmailSender:
     ) -> None:
         """
         Sends an email with the specified parameters (async).
-        Will try to authenticate with the SMTP server
+        Will try to authenticate with the SMTP server.
         if sender_email and sender_password were provided in the constructor.
         """
         import aiosmtplib
@@ -429,17 +430,23 @@ class EmailSender:
             attachments=attachments
         )
 
-        smtp_kwargs: dict[str, object] = {
-            "hostname": self._smtp_server,
-            "port": self._smtp_port,
-            "start_tls": True,
-        }
+        async with aiosmtplib.SMTP(
+            hostname=self._smtp_server,
+            port=self._smtp_port,
+            timeout=60,
+        ) as server:
+            await server.ehlo()
+            try:
+                await server.starttls()
+                await server.ehlo()
+            except (aiosmtplib.errors.SMTPNotSupported, aiosmtplib.errors.SMTPException):
+                # STARTTLS may be unsupported on some port 25 setups.
+                # Fallback to unencrypted connection if STARTTLS fails or is not supported.
+                pass
 
-        if self.sender_email and self._sender_password:
-            smtp_kwargs["username"] = self.sender_email
-            smtp_kwargs["password"] = self._sender_password
+            if self.sender_email and self._sender_password:
+                await server.login(self.sender_email, self._sender_password)
 
-        async with aiosmtplib.SMTP(**smtp_kwargs) as server:
             await server.send_message(
                 msg,
                 from_addr=from_addr,

--- a/src/rkdigi/email_handling.py
+++ b/src/rkdigi/email_handling.py
@@ -1,5 +1,4 @@
 import os
-import re
 import asyncio
 import imaplib
 import smtplib
@@ -113,13 +112,17 @@ class EmailSender:
 
     def _normalize_addresses(
         self,
-        addresses: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
+        addresses: str | tuple[str, str]
+            | Sequence[str | tuple[str, str]] | None,
     ) -> list[str | tuple[str, str]]:
         if addresses is None:
             return []
         if isinstance(addresses, str) and self._is_valid_address(addresses):
             return [addresses]
-        elif isinstance(addresses, tuple) and self._is_valid_address(addresses):
+        elif (
+            isinstance(addresses, tuple)
+            and self._is_valid_address(addresses)
+        ):
             return [addresses]
         else:
             for addr in addresses:
@@ -135,7 +138,8 @@ class EmailSender:
         subject: str,
         body: str,
         cc: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
-        attachments: Sequence[str | tuple[str, bytes | bytearray | memoryview]] | None
+        attachments: Sequence[
+            str | tuple[str, bytes | bytearray | memoryview]] | None
     ) -> tuple[MIMEMultipart, str, Sequence[str]]:
         """
         Method to build the message object and return it
@@ -177,7 +181,8 @@ class EmailSender:
 
         if soup.find():  # If there are any HTML tags, treat as HTML email
             alt = MIMEMultipart("alternative")
-            alt.attach(MIMEText(soup.get_text(separator="\n", strip=True), "plain", "utf-8"))
+            plain_text = soup.get_text(separator="\n", strip=True)
+            alt.attach(MIMEText(plain_text, "plain", "utf-8"))
             alt.attach(MIMEText(body, "html", "utf-8"))
             msg.attach(alt)
         else:
@@ -227,7 +232,8 @@ class EmailSender:
         reply_to: str | tuple[str, str] = "",
         subject: str = "",
         body: str = "",
-        cc: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None = None,
+        cc: str | tuple[str, str]
+        | Sequence[str | tuple[str, str]] | None = None,
         attachments: Sequence[str | tuple[str, bytes]] | None = None
     ) -> None:
         """
@@ -246,7 +252,8 @@ class EmailSender:
                 server.ehlo()
             except smtplib.SMTPException:
                 # STARTTLS may be unsupported on some port 25 setups.
-                # Fallback to unencrypted connection if STARTTLS fails or is not supported.
+                # Fallback to unencrypted connection
+                # if STARTTLS fails or is not supported.
                 pass
             if self.sender_email and self._sender_password:
                 if sender:
@@ -267,7 +274,8 @@ class EmailSender:
 
             if not recipients and not cc:
                 raise ValueError(
-                    "At least one recipient (recipients or cc) must be specified."
+                    "At least one recipient (recipients or cc)"
+                    " must be specified."
                 )
 
             msg, from_addr, to_addrs = self._build_message(
@@ -290,10 +298,12 @@ class EmailSender:
         self,
         sender: str | tuple[str, str] = "",
         reply_to: str | tuple[str, str] | None = None,
-        recipients: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None = None,
+        recipients: str | tuple[str, str]
+        | Sequence[str | tuple[str, str]] | None = None,
         subject: str = "",
         body: str = "",
-        cc: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None = None,
+        cc: str | tuple[str, str]
+        | Sequence[str | tuple[str, str]] | None = None,
         attachments: Sequence[str | tuple[str, bytes]] | None = None
     ) -> None:
         """
@@ -337,9 +347,13 @@ class EmailSender:
             try:
                 await server.starttls()
                 await server.ehlo()
-            except (aiosmtplib.errors.SMTPNotSupported, aiosmtplib.errors.SMTPException):
+            except (
+                aiosmtplib.errors.SMTPNotSupported,
+                aiosmtplib.errors.SMTPException
+            ):
                 # STARTTLS may be unsupported on some port 25 setups.
-                # Fallback to unencrypted connection if STARTTLS fails or is not supported.
+                # Fallback to unencrypted connection
+                # if STARTTLS fails or is not supported.
                 pass
 
             if self.sender_email and self._sender_password:

--- a/src/rkdigi/email_handling.py
+++ b/src/rkdigi/email_handling.py
@@ -4,7 +4,7 @@ import asyncio
 import imaplib
 import smtplib
 from html import unescape
-from typing import Sequence
+from typing import Sequence, TypeGuard
 import email as email_module
 from email import encoders
 from email.utils import formataddr
@@ -68,19 +68,54 @@ class EmailSender:
                 f"{self._smtp_server}:{self._smtp_port}"
             )
 
-    def _check_address_header(self, address: str | tuple[str, str]) -> bool:
+    def _is_address_tuple(self, value: object) -> TypeGuard[tuple[str, str]]:
+        """
+        Method to check if the provided value is a valid address tuple of the form (name, email).
+
+        Tuples are reserved for a *single named address*.
+        Multiple recipients must be provided as a non-tuple sequence (e.g. list).
+
+        To prevent common misuse, we reject tuples where both elements look like
+        emails (e.g. ("a@x", "b@y")); pass ["a@x", "b@y"] instead.
+
+        :param value: The value to check.
+        :return: True if value is a valid (display_name, email) tuple, False otherwise.
+        """
+        if not (isinstance(value, tuple) and len(value) == 2):
+            return False
+
+        name, email = value
+        if not (isinstance(name, str) and isinstance(email, str)):
+            return False
+
+        if "@" not in email:
+            return False
+
+        # Disallow "name" that also looks like an email to avoid ambiguity.
+        if "@" in name:
+            return False
+
+        return True
+
+    def _check_address_header(self, address: str | tuple[str, str] | None) -> bool:
         """
         Method to check if the provided address is a valid address header.
+
+        :param address: The email address to check. Can be a string or a tuple of (display_name, email), for example:
+        - Simple email string: "user@example.com"
+        - Tuple of (display_name, email): ("John Doe", "john.doe@example.com")
+
+        :return: True if the address is valid, False otherwise.
         """
         if isinstance(address, str):
             return '@' in address
-        elif isinstance(address, tuple) and len(address) == 2:
-            return '@' in address[1]
+        elif self._is_address_tuple(address):
+            return True
         return False
 
     def _can_connect(self) -> bool:
         """
-        method to check if connection to
+        Method to check if connection to
         SMTP server can be established.
         """
         try:
@@ -95,6 +130,10 @@ class EmailSender:
             return False
 
     def _is_html(self, body: str) -> bool:
+        """
+        Method to check if the provided body is HTML.
+        Returns True if the body contains HTML tags, False otherwise.
+        """
         if not body:
             return False
         lower = body.lower()
@@ -108,6 +147,10 @@ class EmailSender:
         )
 
     def _html_to_text(self, html: str) -> str:
+        """
+        Method to convert HTML content to plain text.
+        Returns the plain text representation of the HTML content.
+        """
         if not html:
             return ""
 
@@ -159,25 +202,34 @@ class EmailSender:
         text = re.sub(r"[ \t]{2,}", " ", text)
         return text.strip()
 
+    def _normalize_addresses(
+        self,
+        addresses: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
+    ) -> list[str | tuple[str, str]]:
+        if addresses is None:
+            return []
+        if isinstance(addresses, str):
+            return [addresses]
+        if isinstance(addresses, tuple):
+            if self._is_address_tuple(addresses):
+                return [addresses]
+            raise ValueError(
+                "Invalid address tuple. Use (name, email) for a single named address, "
+                "or use a list/other non-tuple sequence for multiple recipients."
+            )
+        return list(addresses)
+
     def _normalize_recipients(
         self,
         recipients: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
     ) -> list[str | tuple[str, str]]:
-        if recipients is None:
-            return []
-        if isinstance(recipients, (str, tuple)):
-            return [recipients]
-        return list(recipients)
+        return self._normalize_addresses(recipients)
 
     def _normalize_cc(
         self,
         cc: str | tuple[str, str] | Sequence[str | tuple[str, str]] | None,
     ) -> list[str | tuple[str, str]]:
-        if cc is None:
-            return []
-        if isinstance(cc, (str, tuple)):
-            return [cc]
-        return list(cc)
+        return self._normalize_addresses(cc)
 
     def _build_message(
         self,
@@ -271,7 +323,7 @@ class EmailSender:
 
     def send_email(
         self,
-        recipients: str | tuple[str, str] | list[str | tuple[str, str]],
+        recipients: str | tuple[str, str] | Sequence[str | tuple[str, str]],
         sender: str | tuple[str, str] = "",
         reply_to: str | tuple[str, str] = "",
         subject: str = "",
@@ -465,6 +517,7 @@ class EmailReader:
         """
         Retrieve emails from the specified mailbox
         matching the search criteria.
+
         param mailbox: The mailbox to search in (e.g., "INBOX")
         param criteria: The IMAP search criteria (e.g., "ALL", "UNSEEN")
         param modifiers: Optional IMAP flags to set on the emails

--- a/src/rkdigi/email_handling.py
+++ b/src/rkdigi/email_handling.py
@@ -449,8 +449,8 @@ class EmailSender:
 
             await server.send_message(
                 msg,
-                from_addr=from_addr,
-                to_addrs=to_addrs
+                sender=from_addr,
+                recipients=to_addrs
             )
 
 

--- a/tests/email_handling/test_email_sender.py
+++ b/tests/email_handling/test_email_sender.py
@@ -2,6 +2,7 @@ import sys
 import types
 import pytest
 import smtplib
+import asyncio
 import email as email_module
 from rkdigi.email_handling import EmailSender
 from unittest.mock import patch
@@ -507,6 +508,15 @@ class FakeSMTP:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         return None
 
+    async def ehlo(self, *args, **kwargs):
+        return None
+
+    async def starttls(self, *args, **kwargs):
+        return None
+
+    async def login(self, *args, **kwargs):
+        return None
+
     async def send_message(self, *args, **kwargs):
         return {}
 
@@ -514,7 +524,60 @@ class FakeSMTP:
 fake_aiosmtplib = types.ModuleType("aiosmtplib")
 fake_aiosmtplib.SMTP = lambda *args, **kwargs: FakeSMTP()
 
+fake_aiosmtplib_errors = types.SimpleNamespace(
+    SMTPException=Exception,
+    SMTPNotSupported=Exception,
+)
+fake_aiosmtplib.errors = fake_aiosmtplib_errors
+
 sys.modules["aiosmtplib"] = fake_aiosmtplib
+
+
+def test_send_email_async_starttls_not_supported_falls_back_to_plaintext():
+    class StartTLSNotSupported(Exception):
+        pass
+
+    class FakeSMTPStartTLSFails(FakeSMTP):
+        def __init__(self, *, starttls_fails: bool):
+            self._starttls_fails = starttls_fails
+            self.send_message_called = False
+
+        async def starttls(self, *args, **kwargs):
+            if self._starttls_fails:
+                raise StartTLSNotSupported("no STARTTLS")
+            return None
+
+        async def send_message(self, *args, **kwargs):
+            self.send_message_called = True
+            return {}
+
+    created: list[FakeSMTPStartTLSFails] = []
+
+    def smtp_factory(*args, **kwargs):
+        inst = FakeSMTPStartTLSFails(starttls_fails=True)
+        created.append(inst)
+        return inst
+
+    with pytest.MonkeyPatch.context() as m:
+        m.setattr(EmailSender, '_can_connect', lambda self: True)
+
+        # Patch the pre-injected fake module.
+        fake_aiosmtplib.SMTP = smtp_factory
+        fake_aiosmtplib.errors.SMTPNotSupported = StartTLSNotSupported
+        fake_aiosmtplib.errors.SMTPException = Exception
+
+        sender = EmailSender(smtp_server='smtp.example.com', smtp_port=25)
+        asyncio.run(
+            sender.send_email_async(
+                sender='from@example.com',
+                recipients=['to@example.com'],
+                subject='Test Subject',
+                body='Test Body',
+            )
+        )
+
+    assert created, "Expected FakeSMTP instance to be created"
+    assert created[0].send_message_called is True
 
 
 # Async tests for EmailSender.send_email_async

--- a/tests/email_handling/test_email_sender.py
+++ b/tests/email_handling/test_email_sender.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import pytest
+import smtplib
 import email as email_module
 from rkdigi.email_handling import EmailSender
 from unittest.mock import patch
@@ -249,6 +250,25 @@ def test_send_email_basic():
         ]
         assert plain_parts
         assert plain_parts[0].get_payload(decode=True).decode('utf-8').strip() == 'Test Body'
+
+
+def test_send_email_starttls_smtpexception_falls_back_to_plaintext():
+    with patch('smtplib.SMTP') as mock_smtp:
+        instance = mock_smtp.return_value.__enter__.return_value
+        instance.starttls.side_effect = smtplib.SMTPException('STARTTLS failed')
+        instance.sendmail.return_value = {}
+        instance.ehlo.return_value = None
+
+        sender = EmailSender(smtp_server='smtp.example.com', smtp_port=25)
+        sender.send_email(
+            sender='from@example.com',
+            recipients=['to@example.com'],
+            subject='Test Subject',
+            body='Test Body'
+        )
+
+        instance.starttls.assert_called_once()
+        instance.sendmail.assert_called_once()
 
 
 def test_send_email_authenticated():

--- a/tests/email_handling/test_email_sender.py
+++ b/tests/email_handling/test_email_sender.py
@@ -5,7 +5,7 @@ import smtplib
 import asyncio
 import email as email_module
 from rkdigi.email_handling import EmailSender
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 
 def test_init_with_server_and_port():
@@ -155,6 +155,7 @@ def test_build_message_valid_address():
         assert 'valid3@example.com' in to_addrs
         assert 'valid4@example.com' in to_addrs
 
+
 def test_build_message_valid_tuple_addresses():
     with patch('smtplib.SMTP'):
         sender = EmailSender(smtp_server='smtp.example.com', smtp_port=25)
@@ -240,10 +241,11 @@ def test_build_message_only_html_body():
 
         alt = msg.get_payload()[0]
         assert alt.get_payload()[0].get_content_subtype() == 'plain'
-        assert alt.get_payload()[0].get_payload(decode=True).decode('utf-8') == 'HTML Body'
+        assert alt.get_payload()[0].get_payload(decode=True) \
+            .decode('utf-8') == 'HTML Body'
         assert alt.get_payload()[1].get_content_subtype() == 'html'
-        assert alt.get_payload()[1].get_payload(decode=True).decode('utf-8') == \
-            '<html><body>HTML Body</body></html>'
+        assert alt.get_payload()[1].get_payload(decode=True) \
+            .decode('utf-8') == '<html><body>HTML Body</body></html>'
 
 
 def test_send_email_basic():
@@ -270,10 +272,12 @@ def test_send_email_basic():
         parsed = email_module.message_from_string(args[2])
         plain_parts = [
             p for p in parsed.walk()
-            if p.get_content_type() == 'text/plain' and p.get_content_disposition() != 'attachment'
+            if p.get_content_type() == 'text/plain'
+            and p.get_content_disposition() != 'attachment'
         ]
         assert plain_parts
-        assert plain_parts[0].get_payload(decode=True).decode('utf-8').strip() == 'Test Body'
+        assert plain_parts[0].get_payload(decode=True) \
+            .decode('utf-8').strip() == 'Test Body'
 
 
 def test_send_email_recipients_name_email_tuple():
@@ -297,7 +301,8 @@ def test_send_email_recipients_name_email_tuple():
 def test_send_email_starttls_smtpexception_falls_back_to_plaintext():
     with patch('smtplib.SMTP') as mock_smtp:
         instance = mock_smtp.return_value.__enter__.return_value
-        instance.starttls.side_effect = smtplib.SMTPException('STARTTLS failed')
+        instance.starttls.side_effect = \
+            smtplib.SMTPException('STARTTLS failed')
         instance.sendmail.return_value = {}
         instance.ehlo.return_value = None
 
@@ -343,10 +348,12 @@ def test_send_email_authenticated():
         parsed = email_module.message_from_string(args[2])
         plain_parts = [
             p for p in parsed.walk()
-            if p.get_content_type() == 'text/plain' and p.get_content_disposition() != 'attachment'
+            if p.get_content_type() == 'text/plain'
+            and p.get_content_disposition() != 'attachment'
         ]
         assert plain_parts
-        assert plain_parts[0].get_payload(decode=True).decode('utf-8').strip() == 'Auth Body'
+        assert plain_parts[0].get_payload(decode=True) \
+            .decode('utf-8').strip() == 'Auth Body'
 
 
 def test_send_email_fail_with_double_sender():
@@ -533,7 +540,14 @@ class FakeSMTP:
     async def login(self, *args, **kwargs):
         return None
 
-    async def send_message(self, message, *, sender=None, recipients=None, **kwargs):
+    async def send_message(
+            self,
+            message,
+            *,
+            sender=None,
+            recipients=None,
+            **kwargs
+    ):
         return {}
 
 
@@ -563,7 +577,14 @@ def test_send_email_async_starttls_not_supported_falls_back_to_plaintext():
                 raise StartTLSNotSupported("no STARTTLS")
             return None
 
-        async def send_message(self, message, *, sender=None, recipients=None, **kwargs):
+        async def send_message(
+                self,
+                message,
+                *,
+                sender=None,
+                recipients=None,
+                **kwargs
+        ):
             self.send_message_called = True
             return {}
 
@@ -758,3 +779,25 @@ async def test_send_email_async_only_cc():
             subject='CC Only',
             body='Body'
         )
+
+
+@pytest.mark.asyncio
+async def test_send_email_async_ehlo_called():
+    smtp_mock = AsyncMock()
+    smtp_mock.__aenter__.return_value = smtp_mock
+    smtp_mock.ehlo = AsyncMock()
+    smtp_mock.starttls = AsyncMock()
+    smtp_mock.send_message = AsyncMock()
+    with patch('aiosmtplib.SMTP', return_value=smtp_mock), \
+         patch(
+            'rkdigi.email_handling.EmailSender._can_connect',
+            return_value=True
+    ):
+        sender = EmailSender(smtp_server='smtp.example.com', smtp_port=25)
+        await sender.send_email_async(
+            sender='from@example.com',
+            recipients='to@example.com',
+            subject='Async Subject',
+            body='Async Body'
+        )
+        smtp_mock.ehlo.assert_called()

--- a/tests/email_handling/test_email_sender.py
+++ b/tests/email_handling/test_email_sender.py
@@ -252,6 +252,18 @@ def test_send_email_basic():
         assert plain_parts[0].get_payload(decode=True).decode('utf-8').strip() == 'Test Body'
 
 
+def test_send_email_recipients_tuple_of_emails_is_rejected():
+    with patch('smtplib.SMTP'):
+        sender = EmailSender(smtp_server='smtp.example.com', smtp_port=25)
+        with pytest.raises(ValueError, match='Invalid address tuple'):
+            sender.send_email(
+                sender='from@example.com',
+                recipients=('to1@example.com', 'to2@example.com'),
+                subject='Tuple Recipients',
+                body='Body'
+            )
+
+
 def test_send_email_starttls_smtpexception_falls_back_to_plaintext():
     with patch('smtplib.SMTP') as mock_smtp:
         instance = mock_smtp.return_value.__enter__.return_value
@@ -472,6 +484,19 @@ def test_send_email_only_cc():
         msg_str = args[2]
         assert "To:" not in msg_str
         assert "Cc: cc1@example.com, cc2@example.com" in msg_str
+
+
+def test_send_email_cc_tuple_of_emails_is_rejected():
+    with patch('smtplib.SMTP'):
+        sender = EmailSender(smtp_server='smtp.example.com', smtp_port=25)
+        with pytest.raises(ValueError, match='Invalid address tuple'):
+            sender.send_email(
+                sender='from@example.com',
+                recipients=['to@example.com'],
+                cc=('cc1@example.com', 'cc2@example.com'),
+                subject='Bad CC Tuple',
+                body='Body'
+            )
 
 
 # Mock aiosmtplib

--- a/tests/email_handling/test_email_sender.py
+++ b/tests/email_handling/test_email_sender.py
@@ -517,7 +517,7 @@ class FakeSMTP:
     async def login(self, *args, **kwargs):
         return None
 
-    async def send_message(self, *args, **kwargs):
+    async def send_message(self, message, *, sender=None, recipients=None, **kwargs):
         return {}
 
 
@@ -547,7 +547,7 @@ def test_send_email_async_starttls_not_supported_falls_back_to_plaintext():
                 raise StartTLSNotSupported("no STARTTLS")
             return None
 
-        async def send_message(self, *args, **kwargs):
+        async def send_message(self, message, *, sender=None, recipients=None, **kwargs):
             self.send_message_called = True
             return {}
 

--- a/tests/email_handling/test_email_sender.py
+++ b/tests/email_handling/test_email_sender.py
@@ -104,30 +104,30 @@ def test_can_connect_false():
         assert sender._can_connect() is False
 
 
-def test_check_address_header_valid():
+def test_is_valid_address_valid():
     with patch('smtplib.SMTP'):
         sender = EmailSender(smtp_server='smtp.example.com', smtp_port=25)
-        assert sender._check_address_header(
+        assert sender._is_valid_address(
             address='example@example.com'
         ) is True
-        assert sender._check_address_header(
+        assert sender._is_valid_address(
             address=('Example', 'example@example.com')
         ) is True
 
 
-def test_check_address_header_invalid():
+def test_is_valid_address_invalid():
     with patch('smtplib.SMTP'):
         sender = EmailSender(smtp_server='smtp.example.com', smtp_port=25)
-        assert sender._check_address_header(
+        assert sender._is_valid_address(
             address='example-example.com'
         ) is False
-        assert sender._check_address_header(
+        assert sender._is_valid_address(
             address=('Example', 'example-example.com')
         ) is False
-        assert sender._check_address_header(
+        assert sender._is_valid_address(
             address=('Example',)
         ) is False
-        assert sender._check_address_header(
+        assert sender._is_valid_address(
             None
         ) is False
 
@@ -142,6 +142,29 @@ def test_build_message_valid_address():
                 'valid3@example.com',
                 ('Valid Recipient', 'valid4@example.com')
             ],
+            subject='Test',
+            body='Body',
+            cc=None,
+            attachments=None
+        )
+
+        assert 'valid1@example.com' == from_addr
+        assert 'valid2@example.com' == msg['Reply-To']
+        assert isinstance(to_addrs, list) and \
+            all(isinstance(addr, str) for addr in to_addrs)
+        assert 'valid3@example.com' in to_addrs
+        assert 'valid4@example.com' in to_addrs
+
+def test_build_message_valid_tuple_addresses():
+    with patch('smtplib.SMTP'):
+        sender = EmailSender(smtp_server='smtp.example.com', smtp_port=25)
+        msg, from_addr, to_addrs = sender._build_message(
+            sender=('Valid Sender', 'valid1@example.com'),
+            reply_to='valid2@example.com',
+            recipients=(
+                'valid3@example.com',
+                ('Valid Recipient', 'valid4@example.com')
+            ),
             subject='Test',
             body='Body',
             cc=None,
@@ -253,16 +276,22 @@ def test_send_email_basic():
         assert plain_parts[0].get_payload(decode=True).decode('utf-8').strip() == 'Test Body'
 
 
-def test_send_email_recipients_tuple_of_emails_is_rejected():
-    with patch('smtplib.SMTP'):
+def test_send_email_recipients_name_email_tuple():
+    with patch('smtplib.SMTP') as mock_smtp:
+        instance = mock_smtp.return_value.__enter__.return_value
+        instance.ehlo.return_value = None
         sender = EmailSender(smtp_server='smtp.example.com', smtp_port=25)
-        with pytest.raises(ValueError, match='Invalid address tuple'):
-            sender.send_email(
-                sender='from@example.com',
-                recipients=('to1@example.com', 'to2@example.com'),
-                subject='Tuple Recipients',
-                body='Body'
-            )
+        sender.send_email(
+            sender='from@example.com',
+            recipients=('To', 'to@example.com'),
+            subject='Tuple Recipients',
+            body='Body'
+        )
+        instance.sendmail.assert_called_once()
+        args = tuple(instance.sendmail.call_args.kwargs.values())
+        msg_str = args[2]
+        parsed = email_module.message_from_string(msg_str)
+        assert parsed['To'] == 'To <to@example.com>'
 
 
 def test_send_email_starttls_smtpexception_falls_back_to_plaintext():
@@ -485,19 +514,6 @@ def test_send_email_only_cc():
         msg_str = args[2]
         assert "To:" not in msg_str
         assert "Cc: cc1@example.com, cc2@example.com" in msg_str
-
-
-def test_send_email_cc_tuple_of_emails_is_rejected():
-    with patch('smtplib.SMTP'):
-        sender = EmailSender(smtp_server='smtp.example.com', smtp_port=25)
-        with pytest.raises(ValueError, match='Invalid address tuple'):
-            sender.send_email(
-                sender='from@example.com',
-                recipients=['to@example.com'],
-                cc=('cc1@example.com', 'cc2@example.com'),
-                subject='Bad CC Tuple',
-                body='Body'
-            )
 
 
 # Mock aiosmtplib

--- a/tests/email_handling/test_email_sender.py
+++ b/tests/email_handling/test_email_sender.py
@@ -1,6 +1,7 @@
 import sys
 import types
 import pytest
+import email as email_module
 from rkdigi.email_handling import EmailSender
 from unittest.mock import patch
 
@@ -210,10 +211,13 @@ def test_build_message_only_html_body():
             cc=None,
             attachments=None
         )
-        assert msg.get_payload()[0].get_content_subtype() == 'plain'
-        assert msg.get_payload()[0].get_payload() == 'HTML Body\n\n'
-        assert msg.get_payload()[1].get_content_subtype() == 'html'
-        assert msg.get_payload()[1].get_payload() == \
+        assert msg.get_payload()[0].get_content_subtype() == 'alternative'
+
+        alt = msg.get_payload()[0]
+        assert alt.get_payload()[0].get_content_subtype() == 'plain'
+        assert alt.get_payload()[0].get_payload(decode=True).decode('utf-8') == 'HTML Body'
+        assert alt.get_payload()[1].get_content_subtype() == 'html'
+        assert alt.get_payload()[1].get_payload(decode=True).decode('utf-8') == \
             '<html><body>HTML Body</body></html>'
 
 
@@ -238,7 +242,13 @@ def test_send_email_basic():
         assert 'to1@example.com' in args[1]
         assert 'to2@example.com' in args[1]
         assert 'Test Subject' in args[2]
-        assert 'Test Body' in args[2]
+        parsed = email_module.message_from_string(args[2])
+        plain_parts = [
+            p for p in parsed.walk()
+            if p.get_content_type() == 'text/plain' and p.get_content_disposition() != 'attachment'
+        ]
+        assert plain_parts
+        assert plain_parts[0].get_payload(decode=True).decode('utf-8').strip() == 'Test Body'
 
 
 def test_send_email_authenticated():
@@ -268,7 +278,13 @@ def test_send_email_authenticated():
         assert 'auth@example.com' in args[0]
         assert 'to@example.com' in args[1]
         assert 'Auth Subject' in args[2]
-        assert 'Auth Body' in args[2]
+        parsed = email_module.message_from_string(args[2])
+        plain_parts = [
+            p for p in parsed.walk()
+            if p.get_content_type() == 'text/plain' and p.get_content_disposition() != 'attachment'
+        ]
+        assert plain_parts
+        assert plain_parts[0].get_payload(decode=True).decode('utf-8').strip() == 'Auth Body'
 
 
 def test_send_email_fail_with_double_sender():
@@ -308,7 +324,7 @@ def test_send_email_no_sender_and_recipients():
         # Test missing sender
         with pytest.raises(
             ValueError,
-            match='A sender and at least one recipient'
+            match='A sender must be specified'
         ):
             sender.send_email(
                 sender='',
@@ -320,7 +336,7 @@ def test_send_email_no_sender_and_recipients():
         # Test missing recipients
         with pytest.raises(
             ValueError,
-            match='A sender and at least one recipient'
+            match='At least one recipient'
         ):
             sender.send_email(
                 sender='from@example.com',
@@ -516,7 +532,7 @@ async def test_send_email_async_no_sender_and_recipients():
         # Test missing sender
         with pytest.raises(
             ValueError,
-            match='A sender and at least one recipient'
+            match='A sender must be specified'
         ):
             await sender.send_email_async(
                 sender='',
@@ -527,7 +543,7 @@ async def test_send_email_async_no_sender_and_recipients():
         # Test missing recipients
         with pytest.raises(
             ValueError,
-            match='A sender and at least one recipient'
+            match='At least one recipient'
         ):
             await sender.send_email_async(
                 sender='from@example.com',


### PR DESCRIPTION
**Changelog**

- Removed the old `html2text` dependency and stopped generating Markdown-like plain text.
- Added simple HTML detection and conversion:
  - `_is_html()` detects when the body looks like HTML.
  - `_html_to_text()` generates a readable plain-text version, including links rendered as `label (url)`.
- Reworked how emails are built (MIME structure):
  - Always builds a `multipart/mixed` message (so attachments are consistent).
  - If the body is HTML, it nests a `multipart/alternative` inside it with both `text/plain` and `text/html`.
- Improved recipient handling:
  - `recipients` and `cc` are normalized consistently.
  - Tuples are now only valid for a single *named* address `(name, email)`.
  - To send to multiple people, use a list like `["a@x", "b@y", ("Name", "c@z")]` (not a tuple of two emails).
- Standardized attachment handling:
  - Supports either file paths or `(filename, bytes)` style attachments.
  - Attachments are base64 encoded and work with the updated mixed/alternative structure.
- Improved SMTP sending behavior (sync + async):
  - Performs `EHLO`, attempts `STARTTLS`, and tolerates servers where `STARTTLS` is unsupported or fails.
  - Keeps the rule that when authenticated sending is used, you cannot override the sender.
  - Async sending now mirrors sync behavior (opportunistic STARTTLS) instead of forcing TLS.
- Added/updated tests:
  - Updated existing assertions to match the new MIME layout and encoding.
  - Added regression tests that simulate `STARTTLS` failures and verify the email still sends (sync and async).
  - Extended the async SMTP test double to support `ehlo`, `starttls`, `login`, and related error behavior.